### PR TITLE
ENHANCEMENT: Allow the default zoom to be configurable

### DIFF
--- a/client/dist/js/MapField.js
+++ b/client/dist/js/MapField.js
@@ -137,11 +137,11 @@ jQuery(function($) {
                 this.setMap(map);
 
                 if (!feature) {
-                    map.setView(this.data('defaultLocation'), 13);
+                    map.setView(this.data('defaultLocation'), this.data('defaultZoom'));
                 } else if (feature.getBounds) {
                     map.fitBounds(feature.getBounds());
                 } else if (feature.getLatLng) {
-                    map.setView(feature.getLatLng(), 13);
+                    map.setView(feature.getLatLng(), this.data('defaultZoom'));
                 }
             },
             getFormField: function() {

--- a/src/Forms/MapField.php
+++ b/src/Forms/MapField.php
@@ -22,6 +22,13 @@ class MapField extends FormField
     ];
 
     /**
+     * Zoom level of the map widget if the MapField is empty
+     *
+     * @var int
+     */
+    private static $default_zoom = 13;
+
+    /**
      * Whether the user can create complex gemoetries like e.g. MultiPoints
      *
      * @var boolean
@@ -89,6 +96,11 @@ class MapField extends FormField
     public function getDefaultLocation()
     {
         return json_encode(Config::inst()->get(MapField::class, 'default_location'));
+    }
+
+    public static function getDefaultZoom()
+    {
+        return Config::inst()->get(MapField::class, 'default_zoom');
     }
 
     public function enableMulti($enable = true)

--- a/templates/Smindel/GIS/Forms/MapField.ss
+++ b/templates/Smindel/GIS/Forms/MapField.ss
@@ -1,2 +1,2 @@
-<div data-field="{$ID}" class="map-field-widget" data-controls="$Controls" data-default-srid="$DefaultSRID" data-default-location="$DefaultLocation" data-multi-enabled="$MultiEnabled"></div>
+<div data-field="{$ID}" class="map-field-widget" data-controls="$Controls" data-default-zoom="$DefaultZoom" data-default-srid="$DefaultSRID" data-default-location="$DefaultLocation" data-multi-enabled="$MultiEnabled"></div>
 <input $AttributesHTML/>


### PR DESCRIPTION
Whilst the location was configurable the default zoom was not, and my use case is to show a default for the whole of Scotland (approximately).

I have added a value called `default_zoom` which is set to the same hardwired value as before, 13, but it is now configurable as below:

```
Smindel\GIS\Forms\MapField:
  default_location:
    lat: 55.9411289
    lon: -3.3454205
  default_zoom: 6
```