### PR TITLE
Make The Initial Layer Configurable

### DIFF
--- a/client/dist/js/MapField.js
+++ b/client/dist/js/MapField.js
@@ -78,14 +78,14 @@ jQuery(function($) {
 
                 var map = L.map(this[0], { worldCopyJump: true, maxBoundsViscosity: 1.0 });
                 var streets = L.tileLayer('//{s}.tile.osm.org/{z}/{x}/{y}.png').addTo(map);
-                var satelite = L.tileLayer('//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+                var satellite = L.tileLayer('//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
                     maxZoom: 20,
                     subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
                 });
 
                 var baseMaps = {
                     "Streets": streets,
-                    "Satelite": satelite
+                    "Satelite": satellite
                 };
 
                 var feature = this.getFeatureFromFormFieldValue();

--- a/client/dist/js/MapField.js
+++ b/client/dist/js/MapField.js
@@ -77,11 +77,16 @@ jQuery(function($) {
                 var me = this;
 
                 var map = L.map(this[0], { worldCopyJump: true, maxBoundsViscosity: 1.0 });
-                var streets = L.tileLayer('//{s}.tile.osm.org/{z}/{x}/{y}.png').addTo(map);
+                var streets = L.tileLayer('//{s}.tile.osm.org/{z}/{x}/{y}.png');
                 var satellite = L.tileLayer('//{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
                     maxZoom: 20,
                     subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
                 });
+
+                var initialLayer = this.data('initialLayer');
+
+                // Add the satellite layer if the initial layer is set to satellite, otherwise fall back to street layer
+                initialLayer == 'satellite' ? satellite.addTo(map) : streets.addTo(map);
 
                 var baseMaps = {
                     "Streets": streets,

--- a/src/Forms/MapField.php
+++ b/src/Forms/MapField.php
@@ -22,6 +22,14 @@ class MapField extends FormField
     ];
 
     /**
+     * The initial layer to show when editing.  The only other permitted value is 'satellite', anything else will
+     * default to 'streets' in order that a map appears in the editing widget
+     *
+     * @var string
+     */
+    private static $initial_layer = 'streets';
+
+    /**
      * Whether the user can create complex gemoetries like e.g. MultiPoints
      *
      * @var boolean
@@ -106,5 +114,10 @@ class MapField extends FormField
     public function getMultiEnabled()
     {
         return $this->multiEnabled;
+    }
+
+    public function getInitialLayer()
+    {
+        return Config::inst()->get(MapField::class, 'initial_layer');
     }
 }

--- a/templates/Smindel/GIS/Forms/MapField.ss
+++ b/templates/Smindel/GIS/Forms/MapField.ss
@@ -1,2 +1,2 @@
-<div data-field="{$ID}" class="map-field-widget" data-controls="$Controls" data-default-srid="$DefaultSRID" data-default-location="$DefaultLocation" data-multi-enabled="$MultiEnabled"></div>
+<div data-field="{$ID}" class="map-field-widget" data-controls="$Controls" data-initial-layer="$InitialLayer" data-default-srid="$DefaultSRID" data-default-location="$DefaultLocation" data-multi-enabled="$MultiEnabled"></div>
 <input $AttributesHTML/>


### PR DESCRIPTION
1) Fixed the spelling of the variable `satelite` to `satellite`
2) Add a configurable static variable called `initial_layer` that if set to `satellite` will render a satellite view in the map editing widget.  Any other value defaults to streets (so as to avoid no map appearing at all due to configuration errors)

```
Smindel\GIS\Forms\MapField:
  default_location:
    lat: 55.9411289
    lon: -3.3454205
  initial_layer: satellite
```