### PR TITLE
FIX: Make Map Size Work Sensibly For 1920x1080 Monitor

### DIFF
--- a/client/dist/css/MapField.css
+++ b/client/dist/css/MapField.css
@@ -14,9 +14,10 @@ input.mapfield_readonly:focus {
 }
 .map-field-widget {
     width:100%;
-    height:150px;
-    transition:1s height;
+    height:25vh;
+    transition:0.05s height;
 }
-.map-field-widget:hover {
-    height:400px;
+
+.form__field-holder > .map-field-widget:hover {
+    height: 75vh;
 }


### PR DESCRIPTION
Possible fix for https://github.com/smindel/silverstripe-gis/issues/5

1) Make the transition on hover much faster
2) Make map being edited 75% of the viewport height.

I'm no CSS wizard, and it's midnight my time, there is possibly a solution with flex. It's the CSS that needs tweaked though